### PR TITLE
Cwd::abs_path is not portable

### DIFF
--- a/lib/File/ConfigDir.pm
+++ b/lib/File/ConfigDir.pm
@@ -281,7 +281,7 @@ pkgsrc ;)
 =cut
 
 my $singleapp_cfg_dir = sub {
-    my @dirs = ( Cwd::abs_path( File::Spec->catdir( $FindBin::RealDir, "..", "etc" ) ) );
+    my @dirs = ( map {eval {Cwd::abs_path($_)} or File::Spec->canonpath($_)} File::Spec->catdir( $FindBin::RealDir, "..", "etc" ) );
     @dirs;
 };
 


### PR DESCRIPTION
It can croak on platforms, and not on others. Switch to
File::Spec->canonpath when it croaks, because File::Spec->canonpath is
guaranteed to do no check on the filesystem.